### PR TITLE
Improve installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ An extension for [nvim-dap](https://github.com/mfussenegger/nvim-dap) providing 
 ## Installation
 
 ```
-Plug 'nvim-dap'
-Plug 'nvim-dap-ruby'
+Plug 'mfussenegger/nvim-dap'
+Plug 'suketa/nvim-dap-ruby'
 ```
 
 ## Usage


### PR DESCRIPTION
The current instructions can cause this error:

```
Invalid argument: nvim-dap (implicit `vim-scripts' expansion is deprecated)
```

Thanks for the great integration btw 👍 