### PR TITLE
Ability to add to existing debugging session and to bin/dev

### DIFF
--- a/lua/dap-ruby.lua
+++ b/lua/dap-ruby.lua
@@ -34,6 +34,7 @@ end
 local function run_cmd(cmd, args, for_current_line, for_current_file)
 	local handle
 	local pid_or_err
+	local stdout = vim.loop.new_pipe(false)
 	local working_dir = find_cmd_dir(cmd)
 	args = args or {}
 	if for_current_line then
@@ -41,7 +42,7 @@ local function run_cmd(cmd, args, for_current_line, for_current_file)
 	elseif for_current_file then
 		table.insert(args, vim.fn.expand("%:p"))
 	end
-	local opts = { args = args, cwd = working_dir }
+	local opts = { args = args, cwd = working_dir, stdio = { nil, stdout } }
 
 	handle, pid_or_err = vim.loop.spawn(cmd, opts, function(code)
 		if handle then
@@ -54,6 +55,15 @@ local function run_cmd(cmd, args, for_current_line, for_current_file)
 	end)
 
 	assert(handle, "Error running command: " .. cmd .. tostring(pid_or_err))
+
+	stdout:read_start(function(err, chunk)
+		assert(not err, err)
+		if chunk then
+			vim.schedule(function()
+				require("dap.repl").append(chunk)
+			end)
+		end
+	end)
 end
 
 local function setup_ruby_adapter(dap)
@@ -96,7 +106,7 @@ local function setup_ruby_configuration(dap)
 		extend_run_config({ name = "run rspec current file", command = "bundle", args = { "exec", "rspec" }, current_file = true }),
 		extend_run_config({ name = "run rspec current_file:current_line", command = "bundle", args = { "exec", "rspec" }, current_line = true }),
 		extend_run_config({ name = "run rspec", command = "bundle", args = { "exec", "rspec" } }),
-		extend_run_config({ name = "bin/dev", command = "bin/dev", local_command = true }),
+		extend_run_config({ name = "bin/dev", command = "bin/dev" }),
 		extend_base_config({ name = "attach existing (port 38698)", port = 38698, waiting = 0 }),
 		extend_base_config({ name = "attach existing (pick port)", waiting = 0 }),
 	}

--- a/lua/dap-ruby.lua
+++ b/lua/dap-ruby.lua
@@ -17,7 +17,13 @@ local function setup_ruby_adapter(dap)
 		if config.command then
 			local handle
 			local pid_or_err
-			local opts = { args = config.args }
+			local args = config.args or {}
+			if config.current_line then
+				table.insert(args, vim.fn.expand("%:p") .. ":" .. vim.fn.line("."))
+			elseif config.current_file then
+				table.insert(args, vim.fn.expand("%:p"))
+			end
+			local opts = { args = args }
 			handle, pid_or_err = vim.loop.spawn(config.command, opts, function(code)
 				handle:close()
 				if code ~= 0 then
@@ -54,52 +60,51 @@ local function setup_ruby_configuration(dap)
 			localfs = true,
 			waiting = 1000,
 		},
-		-- {
-		-- 	type = "ruby",
-		-- 	name = "debug current file",
-		-- 	bundle = "",
-		-- 	request = "attach",
-		-- 	command = "ruby",
-		-- 	script = "${file}",
-		-- 	port = 38698,
-		-- 	server = "127.0.0.1",
-		-- 	options = {
-		-- 		source_filetype = "ruby",
-		-- 	},
-		-- 	localfs = true,
-		-- 	waiting = 1000,
-		-- },
-		-- {
-		-- 	type = "ruby",
-		-- 	name = "run rspec current_file",
-		-- 	bundle = "bundle",
-		-- 	request = "attach",
-		-- 	command = "rspec",
-		-- 	script = "${file}",
-		-- 	port = 38698,
-		-- 	server = "127.0.0.1",
-		-- 	options = {
-		-- 		source_filetype = "ruby",
-		-- 	},
-		-- 	localfs = true,
-		-- 	waiting = 1000,
-		-- },
-		-- {
-		-- 	type = "ruby",
-		-- 	name = "run rspec current_file:current_line",
-		-- 	bundle = "bundle",
-		-- 	request = "attach",
-		-- 	command = "rspec",
-		-- 	script = "${file}",
-		-- 	port = 38698,
-		-- 	server = "127.0.0.1",
-		-- 	options = {
-		-- 		source_filetype = "ruby",
-		-- 	},
-		-- 	localfs = true,
-		-- 	waiting = 1000,
-		-- 	current_line = true,
-		-- },
+		{
+			type = "ruby",
+			name = "debug current file",
+			request = "attach",
+			command = "ruby",
+			current_file = true,
+			port = 38698,
+			server = "127.0.0.1",
+			options = {
+				source_filetype = "ruby",
+			},
+			localfs = true,
+			waiting = 1000,
+		},
+		{
+			type = "ruby",
+			name = "run rspec current_file",
+			request = "attach",
+			command = "bundle",
+			args = { "exec", "rspec" },
+			current_file = true,
+			port = 38698,
+			server = "127.0.0.1",
+			options = {
+				source_filetype = "ruby",
+			},
+			localfs = true,
+			waiting = 1000,
+		},
+		{
+			type = "ruby",
+			name = "run rspec current_file:current_line",
+			request = "attach",
+			command = "bundle",
+			args = { "exec", "rspec" },
+			current_line = true,
+			port = 38698,
+			server = "127.0.0.1",
+			options = {
+				source_filetype = "ruby",
+			},
+			localfs = true,
+			waiting = 1000,
+			current_line = true,
+		},
 		{
 			type = "ruby",
 			name = "run rspec",
@@ -118,6 +123,19 @@ local function setup_ruby_configuration(dap)
 			type = "ruby",
 			name = "attach existing",
 			request = "attach",
+			port = 38698,
+			server = "127.0.0.1",
+			options = {
+				source_filetype = "ruby",
+			},
+			localfs = true,
+			waiting = 1000,
+		},
+		{
+			type = "ruby",
+			name = "run bin/dev",
+			request = "attach",
+			command = "bin/dev",
 			port = 38698,
 			server = "127.0.0.1",
 			options = {

--- a/lua/dap-ruby.lua
+++ b/lua/dap-ruby.lua
@@ -6,59 +6,6 @@ local function load_module(module_name)
 	return module
 end
 
---[[ HOW TO DEBUG
-create script a.rb to debug
-
-```
-  foo = 1
-  binding.break
-  bar = 2
-  baz = 3
-  puts "finish"
-```
-
-run the following command
-```
-rdbg --open --port 38698 -n -- a.rb
-```
-
-run
-```
-nvim a.rb
-:lua require'dap'.continue()
-:lua require'dap'.repl.open()
-```
-
-nvim-dap log files is .cache/nvim/dap.log
-nvim-dap log files is .cache/nvim/dap.log
-]]
-
--- To DEBUG, change '--[[ DEBUG SETTING' => '-- [[ DEBUG SETTING'
---[[ DEBUG SETTING
-local function setup_ruby_adapter(dap)
-  dap.adapters.ruby = function(callback, config)
-    callback({type = "server", host = config.server, port = config.port})
-  end
-end
-
-local function setup_ruby_configuration(dap)
-  dap.set_log_level('TRACE')
-  dap.configurations.ruby = {
-    {
-       type = 'ruby';
-       name = 'debug current file';
-       port = 38698;
-       server = '127.0.0.1';
-       request = 'attach';
-    }
-  }
-end
--- ]]
--- END OF DEBUG SETTING
--- END for nvim-dap-ruby debug
-
--- TO DEBUG, CHANGE '-- [[ => '--[['
--- [[
 local function setup_ruby_adapter(dap)
 	dap.adapters.ruby = function(callback, config)
 		local handle
@@ -199,7 +146,6 @@ local function setup_ruby_configuration(dap)
 		},
 	}
 end
--- ]] -- DONT REMOVE THIS LINE
 
 function M.setup()
 	local dap = load_module("dap")

--- a/lua/dap-ruby.lua
+++ b/lua/dap-ruby.lua
@@ -65,7 +65,7 @@ local function setup_ruby_adapter(dap)
 				end
 			end)
 
-			assert(handle, "Error running rgdb: " .. tostring(pid_or_err))
+			assert(handle, "Error running command: " .. config.command .. tostring(pid_or_err))
 		end
 
 		assert(handle, "Error running rgdb: " .. tostring(pid_or_err))

--- a/lua/dap-ruby.lua
+++ b/lua/dap-ruby.lua
@@ -9,38 +9,16 @@ end
 local function setup_ruby_adapter(dap)
 	dap.adapters.ruby = function(callback, config)
 		local handle
-		local stdout = vim.loop.new_pipe(false)
 		local pid_or_err
 		local waiting = config.waiting or 500
-		local args
-		local script
-		local rdbg
 
-		if config.current_line then
-			script = config.script .. ":" .. vim.fn.line(".")
-		else
-			script = config.script
-		end
+		vim.env.RUBY_DEBUG_OPEN = true
+		vim.env.RUBY_DEBUG_HOST = config.server
+		vim.env.RUBY_DEBUG_PORT = config.port
 
-		if config.bundle == "bundle" then
-			args = { "-n", "--open", "--port", config.port, "-c", "--", "bundle", "exec", config.command, script }
-		else
-			args = { "--open", "--port", config.port, "-c", "--", config.command, script }
-		end
+		local opts = { args = config.args }
 
-		local opts = {
-			stdio = { nil, stdout },
-			args = args,
-			detached = false,
-		}
-
-		if vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1 then
-			rdbg = "rdbg.bat"
-		else
-			rdbg = "rdbg"
-		end
-
-		handle, pid_or_err = vim.loop.spawn(rdbg, opts, function(code)
+		handle, pid_or_err = vim.loop.spawn(config.command, opts, function(code)
 			handle:close()
 			if code ~= 0 then
 				assert(handle, "rdbg exited with code: " .. tostring(code))
@@ -49,15 +27,6 @@ local function setup_ruby_adapter(dap)
 		end)
 
 		assert(handle, "Error running rgdb: " .. tostring(pid_or_err))
-
-		stdout:read_start(function(err, chunk)
-			assert(not err, err)
-			if chunk then
-				vim.schedule(function()
-					require("dap.repl").append(chunk)
-				end)
-			end
-		end)
 
 		-- Wait for rdbg to start
 		vim.defer_fn(function()
@@ -71,10 +40,9 @@ local function setup_ruby_configuration(dap)
 		{
 			type = "ruby",
 			name = "run rails",
-			bundle = "bundle",
 			request = "attach",
-			command = "rails",
-			script = "s",
+			command = "bundle",
+			args = { "exec", "rails", "s" },
 			port = 38698,
 			server = "127.0.0.1",
 			options = {
@@ -83,59 +51,58 @@ local function setup_ruby_configuration(dap)
 			localfs = true,
 			waiting = 1000,
 		},
-		{
-			type = "ruby",
-			name = "debug current file",
-			bundle = "",
-			request = "attach",
-			command = "ruby",
-			script = "${file}",
-			port = 38698,
-			server = "127.0.0.1",
-			options = {
-				source_filetype = "ruby",
-			},
-			localfs = true,
-			waiting = 1000,
-		},
-		{
-			type = "ruby",
-			name = "run rspec current_file",
-			bundle = "bundle",
-			request = "attach",
-			command = "rspec",
-			script = "${file}",
-			port = 38698,
-			server = "127.0.0.1",
-			options = {
-				source_filetype = "ruby",
-			},
-			localfs = true,
-			waiting = 1000,
-		},
-		{
-			type = "ruby",
-			name = "run rspec current_file:current_line",
-			bundle = "bundle",
-			request = "attach",
-			command = "rspec",
-			script = "${file}",
-			port = 38698,
-			server = "127.0.0.1",
-			options = {
-				source_filetype = "ruby",
-			},
-			localfs = true,
-			waiting = 1000,
-			current_line = true,
-		},
+		-- {
+		-- 	type = "ruby",
+		-- 	name = "debug current file",
+		-- 	bundle = "",
+		-- 	request = "attach",
+		-- 	command = "ruby",
+		-- 	script = "${file}",
+		-- 	port = 38698,
+		-- 	server = "127.0.0.1",
+		-- 	options = {
+		-- 		source_filetype = "ruby",
+		-- 	},
+		-- 	localfs = true,
+		-- 	waiting = 1000,
+		-- },
+		-- {
+		-- 	type = "ruby",
+		-- 	name = "run rspec current_file",
+		-- 	bundle = "bundle",
+		-- 	request = "attach",
+		-- 	command = "rspec",
+		-- 	script = "${file}",
+		-- 	port = 38698,
+		-- 	server = "127.0.0.1",
+		-- 	options = {
+		-- 		source_filetype = "ruby",
+		-- 	},
+		-- 	localfs = true,
+		-- 	waiting = 1000,
+		-- },
+		-- {
+		-- 	type = "ruby",
+		-- 	name = "run rspec current_file:current_line",
+		-- 	bundle = "bundle",
+		-- 	request = "attach",
+		-- 	command = "rspec",
+		-- 	script = "${file}",
+		-- 	port = 38698,
+		-- 	server = "127.0.0.1",
+		-- 	options = {
+		-- 		source_filetype = "ruby",
+		-- 	},
+		-- 	localfs = true,
+		-- 	waiting = 1000,
+		-- 	current_line = true,
+		-- },
 		{
 			type = "ruby",
 			name = "run rspec",
-			bundle = "bundle",
 			request = "attach",
-			command = "rspec",
-			script = "./spec",
+			command = "bundle",
+			args = { "exec", "rspec" },
 			port = 38698,
 			server = "127.0.0.1",
 			options = {


### PR DESCRIPTION
I've made fork and want to share it with you incase there is anything that you would like to use.

If you are considering accepting this PR and would like me to make any changes or update the readme etc then please let me know.

Instead of running `rdbg` I've gone for running the programs as normal, but first setting the env variables that tells the debugger to start.

This allows:
-  Attaching to existing debugging sessions
-  Running commands like `bin/dev` that might not be possilbe to run by passing as an argument to `rdbg` (e.g. on projects that use esbuild)

I've also done things like allow random ephemeral ports for the debugger (so that you can run debuggers from multiple projects at the same time, or maybe even for `rails s` and `rspec`), and allow the user to pick a port when one isn't specified and they don't want a random one e.g when connecting to an existing session on a known port.

It will also traverse the path to find the command if it is not in path e.g. if you want to run `bin/dev` but you run it from `app/models/something.rb`

~~The only potential downside if that you still get the REPL, but dont get stdout passed into it. My main goal was to have it work with `bin/dev` and when connecting to existing sessions. Maybe there is a solution somehere e.g. to offer these things as a config option.~~ added stdout this back in, it might be noisy with `bin/dev` but doesn't get in the way of typing commands into REPL.