### PR TITLE
add -rdebug when running debug current file

### DIFF
--- a/lua/dap-ruby.lua
+++ b/lua/dap-ruby.lua
@@ -105,7 +105,7 @@ local function setup_ruby_configuration(dap)
 	end
 	dap.configurations.ruby = {
 		extend_run_config({ name = "run rails", command = "bundle", args = { "exec", "rails", "s" } }),
-		extend_run_config({ name = "debug current file", command = "ruby", current_file = true }),
+		extend_run_config({ name = "debug current file", command = "ruby", args = { "-rdebug" }, current_file = true }),
 		extend_run_config({ name = "run rspec current file", command = "bundle", args = { "exec", "rspec" }, current_file = true }),
 		extend_run_config({ name = "run rspec current_file:current_line", command = "bundle", args = { "exec", "rspec" }, current_line = true }),
 		extend_run_config({ name = "run rspec", command = "bundle", args = { "exec", "rspec" } }),


### PR DESCRIPTION
I think debug.rb is needed to load (`require 'debug'`) when debugging current file.

So, add `-rdebug` option when debugging current file.