### PR TITLE
Update dap-ruby.lua

### DIFF
--- a/lua/dap-ruby.lua
+++ b/lua/dap-ruby.lua
@@ -104,8 +104,8 @@ local function setup_ruby_configuration(dap)
 		return vim.tbl_extend("force", run_config, config)
 	end
 	dap.configurations.ruby = {
+		extend_run_config({ name = "debug current file", command = "rdbg",  current_file = true }),
 		extend_run_config({ name = "run rails", command = "bundle", args = { "exec", "rails", "s" } }),
-		extend_run_config({ name = "debug current file", command = "ruby", args = { "-rdebug" }, current_file = true }),
 		extend_run_config({ name = "run rspec current file", command = "bundle", args = { "exec", "rspec" }, current_file = true }),
 		extend_run_config({ name = "run rspec current_file:current_line", command = "bundle", args = { "exec", "rspec" }, current_line = true }),
 		extend_run_config({ name = "run rspec", command = "bundle", args = { "exec", "rspec" } }),


### PR DESCRIPTION
I made a mistake in my previous operation, so I will send a Pull Request again.
I've changed it from rdebug to rdbg, as I learned that rdbg is now the standard for Ruby 3.1 and later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the Ruby debug configuration to use the latest debugging tool for improved compatibility and reliability when debugging the current file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->