### PR TITLE
Attach minitest current file

### DIFF
--- a/lua/dap-ruby.lua
+++ b/lua/dap-ruby.lua
@@ -109,6 +109,7 @@ local function setup_ruby_configuration(dap)
 		extend_run_config({ name = "run rspec current file", command = "bundle", args = { "exec", "rspec" }, current_file = true }),
 		extend_run_config({ name = "run rspec current_file:current_line", command = "bundle", args = { "exec", "rspec" }, current_line = true }),
 		extend_run_config({ name = "run rspec", command = "bundle", args = { "exec", "rspec" } }),
+		extend_run_config({ name = "run minitest current file", command = "bundle", args = { "exec", "ruby", '-Itest' }, current_file = true }),
 		extend_run_config({ name = "bin/dev", command = "bin/dev" }),
 		extend_base_config({ name = "attach existing (port 38698)", port = 38698, waiting = 0 }),
 		extend_base_config({ name = "attach existing (pick port)", waiting = 0 }),


### PR DESCRIPTION
Added one extra command to be able to run a Minitest test file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "run minitest current file" configuration for the Ruby DAP adapter, enabling direct execution of tests for the currently active file during debugging sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suketa/nvim-dap-ruby/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->